### PR TITLE
Extend filter for profilers.

### DIFF
--- a/config_examples/azure_sql.yaml
+++ b/config_examples/azure_sql.yaml
@@ -14,6 +14,7 @@ plugins:
     encrypt: "Expected values: 'yes'|'no'. Default is 'yes' "
     trust_server_certificate: "Expected values: 'yes'|'no'. Default is 'no' "
     connection_timeout: "Default value is 30"
-    tables: [ "table_name" ] # Optional
-                             # If present - profiler generates statistics only for tables from the list
-                             # If skipped - profiler generates statistics for all tables
+    filters:
+      {'schema_name': ['table_name']} # Dictionary where key is a schema name and value is a list of table names.
+                                      # If present - profiler generates statistics only for tables according schema.
+                                      # If skipped - profiler generates statistics for all tables.

--- a/odd_collector_profiler/domain/config.py
+++ b/odd_collector_profiler/domain/config.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from textwrap import dedent
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, SecretStr
 from sqlalchemy.engine import URL
@@ -13,6 +13,7 @@ class Config(BaseModel):
 
 class DatabaseConfig(ABC, Config):
     tables: Optional[List[str]] = None
+    filters: Optional[Dict[str, List[str]]] = None
 
     @abstractmethod
     def connection_str(self) -> str:

--- a/odd_collector_profiler/helpers/sql_dialect.py
+++ b/odd_collector_profiler/helpers/sql_dialect.py
@@ -1,8 +1,9 @@
+from collections import defaultdict
 from contextlib import contextmanager
 from typing import Iterable, Set
 
 import pandas as pd
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Connection, Engine, Inspector
 
 from odd_collector_profiler.domain.config import DatabaseConfig
@@ -34,6 +35,31 @@ class SQLDialect:
 
         for table_name in tables:
             yield table_name
+
+    def get_schemas_tables(self):
+        """
+        Get main schemas and tables as dict:
+        {schema_name: [table_name,...,]}
+        """
+        if not self.config.filters:
+            return self.config.filters
+
+        # Query to get all information about base table.
+        query = """
+            SELECT
+                table_schema,
+                table_name
+            FROM information_schema.tables
+            WHERE TABLE_TYPE <> 'VIEW'
+        """
+        with self.connect() as connection:
+            result_as_dict = defaultdict(list)
+            query_result = connection.execute(text(query))
+            a = query_result.fetchall()
+            for i in a:
+                result_as_dict[i[0]].append(i[1])
+
+            return result_as_dict
 
     @staticmethod
     def get_data_frame(table_name: str, connection: Connection):

--- a/odd_collector_profiler/profilers/azure_sql/profiler.py
+++ b/odd_collector_profiler/profilers/azure_sql/profiler.py
@@ -32,14 +32,11 @@ class AzureSQLProfiler(Profiler, SQLDialect):
         items: List[DataSetStatistics] = []
 
         with self.connect() as connection:
-            # The principal_id field is an ID of the principal that owns this schema.
-            query = "SELECT name FROM sys.schemas WHERE principal_id=1"
-            query_result = connection.execute(text(query))
-            main_schemas = [i[0] for i in query_result.fetchall()]
-            for schema in main_schemas:
+            data = self.get_schemas_tables()
+            for schema in data:
                 items.extend(
                     self.get_dataset_statistic(schema, table, connection)
-                    for table in self.get_tables(schema)
+                    for table in data[schema]
                 )
 
             return DatasetStatisticsList(items=items)

--- a/odd_collector_profiler/profilers/azure_sql/profiler.py
+++ b/odd_collector_profiler/profilers/azure_sql/profiler.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Tuple
 from funcy import lmap
 from odd_models.models import DataSetFieldStat, DataSetStatistics, DatasetStatisticsList
 from oddrn_generator import AzureSQLGenerator
-from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 from odd_collector_profiler.domain.config import AzureSQLConfig
@@ -32,7 +31,7 @@ class AzureSQLProfiler(Profiler, SQLDialect):
         items: List[DataSetStatistics] = []
 
         with self.connect() as connection:
-            data = self.get_schemas_tables()
+            data = self.get_base_table_info()
             for schema in data:
                 items.extend(
                     self.get_dataset_statistic(schema, table, connection)


### PR DESCRIPTION
Added the field `filters` into collector_config.yaml. This field expects a dictionary where the key is the schema name and the value is a list of table names related to the current schema. The exact structure from the get_schemas_tables method from the sql_dialect.py module will be returned if the `filters` field is empty in the collector_config.yaml.
